### PR TITLE
Update src/RouteMagic/Internals/RedirectRoute.cs

### DIFF
--- a/src/RouteMagic/Internals/RedirectRoute.cs
+++ b/src/RouteMagic/Internals/RedirectRoute.cs
@@ -100,10 +100,10 @@ namespace RouteMagic.Internals
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
             var requestRouteValues = requestContext.RouteData.Values;
+            
+            var mergedRouteValues = AdditionalRouteValues != null ? AdditionalRouteValues.Merge(requestRouteValues) : new RouteValueDictionary();
 
-            var routeValues = AdditionalRouteValues.Merge(requestRouteValues);
-
-            var vpd = TargetRoute.GetVirtualPath(requestContext, routeValues);
+            var vpd = TargetRoute.GetVirtualPath(requestContext, mergedRouteValues);
             if (vpd != null)
             {
                 string targetUrl = "~/" + vpd.VirtualPath;


### PR DESCRIPTION
Updated route value processing to not explicitly pass in additional route values if none are passed to the To() method. This keeps origin route values from being added to the querystring of the redirect url which are not defined as part of the destination route.
