### PR TITLE
Query String rerouting and optional action to call during rerouting

### DIFF
--- a/src/RouteMagic/Internals/RedirectRoute.cs
+++ b/src/RouteMagic/Internals/RedirectRoute.cs
@@ -14,12 +14,17 @@ namespace RouteMagic.Internals
         {
         }
 
+        public RedirectRoute(RouteBase sourceRoute, RouteBase targetRoute, bool permanent, RouteValueDictionary additionalRouteValues)
+            : this(sourceRoute, targetRoute, permanent, additionalRouteValues, null)
+        {
+        }
+
         public RedirectRoute(
-            RouteBase sourceRoute, 
-            RouteBase targetRoute, 
-            bool permanent, 
-            RouteValueDictionary additionalRouteValues, 
-            Action<RequestContext, RedirectRoute> onRedirectAction = null)
+            RouteBase sourceRoute,
+            RouteBase targetRoute,
+            bool permanent,
+            RouteValueDictionary additionalRouteValues,
+            Action<RequestContext, RedirectRoute> onRedirectAction)
         {
             SourceRoute = sourceRoute;
             TargetRoute = targetRoute;
@@ -28,7 +33,7 @@ namespace RouteMagic.Internals
             OnRedirectAction = onRedirectAction;
         }
 
-        public Action<RequestContext, RedirectRoute> OnRedirectAction { get; set; }
+        public Action<RequestContext, RedirectRoute> OnRedirectAction { get; private set; }
 
         public RouteBase SourceRoute
         {
@@ -123,10 +128,13 @@ namespace RouteMagic.Internals
 
                 //add query strings
                 var qsHelper = requestContext.HttpContext.Request.QueryString;
-                var queryString = String.Join("&", qsHelper.AllKeys.Select(i => i + "=" + qsHelper[i]));
-                if (!string.IsNullOrWhiteSpace(queryString))
+                if (qsHelper != null)
                 {
-                    targetUrl += "?" + queryString;
+                    var queryString = String.Join("&", qsHelper.AllKeys.Select(key => key + "=" + qsHelper[key]));
+                    if (!string.IsNullOrWhiteSpace(queryString))
+                    {
+                        targetUrl += "?" + queryString;
+                    }
                 }
 
                 return new RedirectHttpHandler(targetUrl, Permanent, isReusable: false);

--- a/src/RouteMagic/Internals/RedirectRoute.cs
+++ b/src/RouteMagic/Internals/RedirectRoute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Web;
 using System.Web.Routing;
 using RouteMagic.HttpHandlers;
@@ -107,6 +108,15 @@ namespace RouteMagic.Internals
             if (vpd != null)
             {
                 string targetUrl = "~/" + vpd.VirtualPath;
+
+                //add query strings
+                var qsHelper = requestContext.HttpContext.Request.QueryString;
+                var queryString = String.Join("&", qsHelper.AllKeys.Select(i => i + "=" + qsHelper[i]));
+                if (!string.IsNullOrWhiteSpace(queryString))
+                {
+                    targetUrl += "?" + queryString;
+                }
+
                 return new RedirectHttpHandler(targetUrl, Permanent, isReusable: false);
             }
             return new DelegateHttpHandler(rc => rc.HttpContext.Response.StatusCode = 404, requestContext.RouteData, false);

--- a/src/RouteMagic/RedirectRouteExtensions.cs
+++ b/src/RouteMagic/RedirectRouteExtensions.cs
@@ -9,7 +9,11 @@ namespace RouteMagic
         // We always want to map the RedirectRoute *BEFORE* the legacy route that we're going to redirect.
         // Otherwise the redirect route will never match because the legacy route will supersede it. 
         // Hence the Func<RouteCollection, RouteBase>.
-        public static RedirectRoute Redirect(this RouteCollection routes, Func<RouteCollection, RouteBase> routeMapping, bool permanent = false)
+        public static RedirectRoute Redirect(
+            this RouteCollection routes, 
+            Func<RouteCollection, RouteBase> routeMapping, 
+            bool permanent = false,
+            Action<RequestContext, RedirectRoute> onRedirectAction = null)
         {
             if (routes == null)
             {
@@ -23,7 +27,7 @@ namespace RouteMagic
             var routeCollection = new RouteCollection();
             var legacyRoute = routeMapping(routeCollection);
 
-            var redirectRoute = new RedirectRoute(legacyRoute, null, permanent, null);
+            var redirectRoute = new RedirectRoute(legacyRoute, null, permanent, null, onRedirectAction);
             routes.Add(new NormalizeRoute(redirectRoute));
             return redirectRoute;
         }


### PR DESCRIPTION
Updates  RedirectRoute class which handles query strings in redirects, and allows for a specified Action to call during redirects, which may be helpful during logging.

For Example:
```C#
var defaults = new
{
    controller = "Home",
    action = "Index",
    id = UrlParameter.Optional
};

var newRoute = routes.MapRoute("Default_WithStreet", "Street/{controller}/{action}/{id}", defaults);
routes.Redirect(r => r.MapRoute("Default", "{controller}/{action}/{id}", defaults)).To(newRoute);
```
   
With this route config, <code>Home/LivingRoom?furniture=Couch</code> will automagically be rerouted to <code>Street/Home/LivingRoom?furniture=Couch</code>, whereas RouteMagic would redirect instead to just <code>Street/Home/LivingRoom</code>.

Additionally, we can supply an action to run during a redirection:
```C#
routes.Redirect(r => r.MapRoute("Default", "{controller}/{action}/{id}", defaults), onRedirectAction: SomeImportantAction).To(newRoute);
    
...

public static void SomeImportantAction(RequestContext context, RedirectRouteExtended rre)
{
    Logger.Info("Redirected: " + context.HttpContext.Request.Url.AbsoluteUri);
}
```
    
And 'SomeImportantAction' will be called whenever the redirect happens. Squeeeeeeee!