### PR TITLE
Prevent race in OnBeginRequest

### DIFF
--- a/src/RouteDebug/RouteDebuggerHttpModule.cs
+++ b/src/RouteDebug/RouteDebuggerHttpModule.cs
@@ -14,8 +14,15 @@ namespace RouteDebug
 
         static void OnBeginRequest(object sender, System.EventArgs e)
         {
-            if (RouteTable.Routes.Last() != DebugRoute.Singleton)
+            if (RouteTable.Routes.Last() == DebugRoute.Singleton)
+                return;
+
+            using (RouteTable.Routes.GetWriteLock())
             {
+                // We may have lost the race (if any), check again
+                if (RouteTable.Routes.Last() == DebugRoute.Singleton)
+                    return;
+
                 RouteTable.Routes.Add(DebugRoute.Singleton);
             }
         }


### PR DESCRIPTION
When adding routes to ``RouteTable`` we need to lock it to prevent multiple entries being added by multiple simultaneous requests. We got bit by this at work were RouteDebugger was accidentally left on in production and after an app-pool recycle managed to add multiple entries of the same route due to a race, leaving the app in a faulted state. Leaving RouteDebugger on in production is obviously bad practice, but I guess this might help people testing locally as well.