### PR TITLE
Added transform for Nuget web.config transform

### DIFF
--- a/src/RouteDebug/Web.config.transform
+++ b/src/RouteDebug/Web.config.transform
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="RouteDebugger:Enabled" value="true"/>
+    <add key="RouteDebugger:Enabled" value="true" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
The transform in the project causes a line to be added in the target `web.config`. However, if that line already exists (i.e. when updating Nuget packages) it still gets added and you end up with 2 entries. This is valid in a `web.config` file and the last entry is the one that gets used. Took me a while to figure out I had multiple entries after updating my packages today so thought I'd supply this fix.

This change uses the standard [Microsoft](https://msdn.microsoft.com/en-us/library/dd465326.aspx) transform syntax to only update the existing entry. Nuget info is [here](https://docs.nuget.org/create/configuration-file-and-source-code-transformations) if needed.